### PR TITLE
fix: Broken MCP Server Docker Container on Fedora Linux (needs registry)

### DIFF
--- a/examples/langchain4j-example/src/main/java/io/workm8/agui4j/example/config/AgUiConfig.java
+++ b/examples/langchain4j-example/src/main/java/io/workm8/agui4j/example/config/AgUiConfig.java
@@ -40,7 +40,7 @@ public class AgUiConfig {
             .build();
 
         var transport = new StdioMcpTransport.Builder()
-            .command(List.of("docker", "run", "--rm", "-i", "mcp/sequentialthinking"))
+            .command(List.of("docker", "run", "--rm", "-i", "docker.io/mcp/sequentialthinking"))
             .logEvents(true)
             .build();
 


### PR DESCRIPTION
## 📋 Pull Request Summary

### Type of Change
<!-- Please select the type of change this PR introduces -->
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes, no API changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test improvements
- [ ] 🔨 Build/CI changes
- [ ] 🔌 Integration addition

### Affected Module(s)
<!-- Check all that apply -->
- [ ] `packages/core`
- [ ] `packages/client`
- [ ] `packages/http`
- [ ] `packages/spring-http`
- [ ] `utils/json`
- [ ] `integrations/spring-ai`
- [ ] Documentation
- [ ] CI/CD
- [X] Other (specify): examples

## 📝 Description

### What does this PR do?

Fix broken example on Fedora Linux.

### Why is this change needed?

Without this, start-up is blocked, because `podman` asks for registry.

### How does this change address the problem?

With this, it works.